### PR TITLE
feat: dynamic db connections and schema handling

### DIFF
--- a/src/main/java/dev/paraplan/app/controller/AnalyzeController.java
+++ b/src/main/java/dev/paraplan/app/controller/AnalyzeController.java
@@ -42,14 +42,16 @@ public class AnalyzeController {
 
   @PostMapping("/analyze")
   public AnalyzeResponse analyze(@RequestBody AnalyzeRequest req) throws Exception {
+    String connId = req.connectionId();
+    String schema = req.schema();
     String sql = req.sql();
-    String json = explainService.explainJson(sql);
+    String json = explainService.explainJson(connId, schema, sql);
     PlanFeatures features = explainService.parse(json, sql);
     PredictedMetrics predicted = costPredictor.predict(features);
-    LandscapeReport landscape = landscapeService.scan(sql);
-    SelectivityReport selectivity = probeService.probe(sql);
+    LandscapeReport landscape = landscapeService.scan(connId, schema, sql);
+    SelectivityReport selectivity = probeService.probe(connId, schema, sql);
     int samples = req.options() != null && req.options().mcSamples() != null ? req.options().mcSamples() : 25;
-    Distribution distribution = monteCarloService.simulate(sql, samples);
+    Distribution distribution = monteCarloService.simulate(connId, schema, sql, samples);
 
     List<Recommendation> recs = recommendationService.build(features, predicted);
 

--- a/src/main/java/dev/paraplan/app/controller/ConnectionController.java
+++ b/src/main/java/dev/paraplan/app/controller/ConnectionController.java
@@ -1,0 +1,29 @@
+package dev.paraplan.app.controller;
+
+import dev.paraplan.app.model.CreateConnectionRequest;
+import dev.paraplan.app.model.CreateConnectionResponse;
+import dev.paraplan.app.service.ConnectionManager;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Collection;
+
+@RestController
+@RequestMapping("/api/connection")
+public class ConnectionController {
+    private final ConnectionManager connections;
+
+    public ConnectionController(ConnectionManager connections) {
+        this.connections = connections;
+    }
+
+    @GetMapping
+    public Collection<String> list() {
+        return connections.listIds();
+    }
+
+    @PostMapping
+    public CreateConnectionResponse create(@RequestBody CreateConnectionRequest req) {
+        String id = connections.create(req.host(), req.port(), req.database(), req.user(), req.password());
+        return new CreateConnectionResponse(id);
+    }
+}

--- a/src/main/java/dev/paraplan/app/model/AnalyzeRequest.java
+++ b/src/main/java/dev/paraplan/app/model/AnalyzeRequest.java
@@ -1,3 +1,3 @@
 package dev.paraplan.app.model;
 
-public record AnalyzeRequest(String sql, AnalyzeOptions options) {}
+public record AnalyzeRequest(String connectionId, String schema, String sql, AnalyzeOptions options) {}

--- a/src/main/java/dev/paraplan/app/model/CreateConnectionRequest.java
+++ b/src/main/java/dev/paraplan/app/model/CreateConnectionRequest.java
@@ -1,0 +1,3 @@
+package dev.paraplan.app.model;
+
+public record CreateConnectionRequest(String host, int port, String database, String user, String password) {}

--- a/src/main/java/dev/paraplan/app/model/CreateConnectionResponse.java
+++ b/src/main/java/dev/paraplan/app/model/CreateConnectionResponse.java
@@ -1,0 +1,3 @@
+package dev.paraplan.app.model;
+
+public record CreateConnectionResponse(String id) {}

--- a/src/main/java/dev/paraplan/app/service/ConnectionManager.java
+++ b/src/main/java/dev/paraplan/app/service/ConnectionManager.java
@@ -1,0 +1,51 @@
+package dev.paraplan.app.service;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.stereotype.Service;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class ConnectionManager {
+    private final Map<String, DataSource> connections = new ConcurrentHashMap<>();
+
+    public String create(String host, int port, String database, String user, String password) {
+        HikariConfig cfg = new HikariConfig();
+        cfg.setJdbcUrl("jdbc:postgresql://" + host + ":" + port + "/" + database);
+        cfg.setUsername(user);
+        cfg.setPassword(password);
+        cfg.setMaximumPoolSize(4);
+        cfg.setMinimumIdle(0);
+        HikariDataSource ds = new HikariDataSource(cfg);
+        String id = UUID.randomUUID().toString();
+        connections.put(id, ds);
+        return id;
+    }
+
+    public Collection<String> listIds() {
+        return connections.keySet();
+    }
+
+    public Connection getConnection(String id, String schema) throws SQLException {
+        DataSource ds = connections.get(id);
+        if (ds == null) {
+            throw new IllegalArgumentException("Unknown connection id: " + id);
+        }
+        Connection c = ds.getConnection();
+        if (schema != null && !schema.isEmpty()) {
+            try (Statement st = c.createStatement()) {
+                st.execute("SET search_path TO " + schema);
+            }
+        }
+        return c;
+    }
+}
+

--- a/src/main/java/dev/paraplan/app/service/ExplainService.java
+++ b/src/main/java/dev/paraplan/app/service/ExplainService.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.paraplan.app.model.PlanFeatures;
 import org.springframework.stereotype.Service;
 
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -13,12 +12,12 @@ import java.util.Locale;
 
 @Service
 public class ExplainService {
-    private final DataSource ds;
+    private final ConnectionManager connections;
     private static final ObjectMapper M = new ObjectMapper();
-    public ExplainService(DataSource ds) { this.ds = ds; }
+    public ExplainService(ConnectionManager connections) { this.connections = connections; }
 
-    public String explainJson(String sql) throws Exception {
-        try (Connection c = ds.getConnection();
+    public String explainJson(String connectionId, String schema, String sql) throws Exception {
+        try (Connection c = connections.getConnection(connectionId, schema);
              PreparedStatement ps = c.prepareStatement("EXPLAIN (FORMAT JSON, COSTS, BUFFERS) " + sql)) {
             try (ResultSet rs = ps.executeQuery()) {
                 StringBuilder sb = new StringBuilder();
@@ -29,8 +28,8 @@ public class ExplainService {
     }
 
     public PlanFeatures parse(String explainJson, String originalSql) throws Exception {
-        com.fasterxml.jackson.databind.JsonNode root = M.readTree(explainJson);
-        com.fasterxml.jackson.databind.JsonNode plan = root.get(0).get("Plan");
+        JsonNode root = M.readTree(explainJson);
+        JsonNode plan = root.get(0).get("Plan");
         double totalCost = plan.has("Total Cost") ? plan.get("Total Cost").asDouble(0d) : 0d;
         long planRows = plan.has("Plan Rows") ? plan.get("Plan Rows").asLong(0) : 0;
         Walker w = new Walker(); w.walk(plan);

--- a/src/main/java/dev/paraplan/app/service/LandscapeService.java
+++ b/src/main/java/dev/paraplan/app/service/LandscapeService.java
@@ -5,7 +5,6 @@ import dev.paraplan.app.model.PlanFeatures;
 import dev.paraplan.app.model.PlanVariant;
 import org.springframework.stereotype.Service;
 
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -13,11 +12,11 @@ import java.util.*;
 
 @Service
 public class LandscapeService {
-    private final DataSource ds;
+    private final ConnectionManager connections;
     private final ExplainService explain;
-    public LandscapeService(DataSource ds, ExplainService explain) { this.ds = ds; this.explain = explain; }
+    public LandscapeService(ConnectionManager connections, ExplainService explain) { this.connections = connections; this.explain = explain; }
 
-    public LandscapeReport scan(String sql) throws Exception {
+    public LandscapeReport scan(String connectionId, String schema, String sql) throws Exception {
         List<Map<String,String>> toggles = List.of(
                 Map.of("enable_seqscan","off","enable_indexscan","on"),
                 Map.of("enable_hashjoin","off","enable_nestloop","on"),
@@ -25,7 +24,7 @@ public class LandscapeService {
                 Map.of("enable_indexonlyscan","on"),
                 Map.of("enable_bitmapscan","on")
         );
-        String baseJson = explain.explainJson(sql);
+        String baseJson = explain.explainJson(connectionId, schema, sql);
         PlanFeatures baseF = explain.parse(baseJson, sql);
         double baseCost = baseF.totalCost();
 
@@ -34,7 +33,7 @@ public class LandscapeService {
         List<Double> vals = new ArrayList<>();
         vals.add(baseCost);
 
-        try (Connection c = ds.getConnection()) {
+        try (Connection c = connections.getConnection(connectionId, schema)) {
             c.setAutoCommit(false);
             for (var t: toggles) {
                 try (Statement st = c.createStatement()) {

--- a/src/main/java/dev/paraplan/app/service/MonteCarloService.java
+++ b/src/main/java/dev/paraplan/app/service/MonteCarloService.java
@@ -14,12 +14,12 @@ public class MonteCarloService {
         this.predictor = predictor; this.explain = explain;
     }
 
-    public Distribution simulate(String sql, int samples) throws Exception {
+    public Distribution simulate(String connectionId, String schema, String sql, int samples) throws Exception {
         samples = Math.max(10, Math.min(200, samples));
         Random rnd = new Random(42);
         List<Long> lat = new ArrayList<>();
         for (int i=0;i<samples;i++) {
-            String json = explain.explainJson(sql);
+            String json = explain.explainJson(connectionId, schema, sql);
             PlanFeatures f = explain.parse(json, sql);
             PredictedMetrics pm = predictor.predict(f);
             long jitter = (long)(pm.p50ms() * (0.8 + rnd.nextDouble()*0.8));

--- a/src/main/java/dev/paraplan/app/service/ProbeService.java
+++ b/src/main/java/dev/paraplan/app/service/ProbeService.java
@@ -3,7 +3,6 @@ package dev.paraplan.app.service;
 import dev.paraplan.app.model.SelectivityReport;
 import org.springframework.stereotype.Service;
 
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -12,22 +11,22 @@ import java.util.Map;
 
 @Service
 public class ProbeService {
-    private final DataSource ds;
-    public ProbeService(DataSource ds) { this.ds = ds; }
+    private final ConnectionManager connections;
+    public ProbeService(ConnectionManager connections) { this.connections = connections; }
 
-    public SelectivityReport probe(String sql) {
+    public SelectivityReport probe(String connectionId, String schema, String sql) {
         Map<String,Double> single = new LinkedHashMap<>();
         Map<String,Double> pairs = new LinkedHashMap<>();
         if (sql.toLowerCase().contains("customers") && sql.toLowerCase().contains("email") && sql.contains("%@example.com")) {
-            double sel = fastSelectivity("customers", "email ILIKE '%@example.com'");
+            double sel = fastSelectivity(connectionId, schema, "customers", "email ILIKE '%@example.com'");
             single.put("customers.email ILIKE '%@example.com'", sel);
         }
         return new SelectivityReport(single, pairs);
     }
 
-    private double fastSelectivity(String table, String predicate) {
+    private double fastSelectivity(String connectionId, String schema, String table, String predicate) {
         String q = "SELECT (SELECT count(*) FROM " + table + " WHERE " + predicate + ")::float / GREATEST((SELECT count(*) FROM " + table + "),1)";
-        try (Connection c = ds.getConnection(); Statement st = c.createStatement(); ResultSet rs = st.executeQuery(q)) {
+        try (Connection c = connections.getConnection(connectionId, schema); Statement st = c.createStatement(); ResultSet rs = st.executeQuery(q)) {
             if (rs.next()) return Math.max(0.0, Math.min(1.0, rs.getDouble(1)));
         } catch (Exception e) { /* ignore for demo */ }
         return 0.1;


### PR DESCRIPTION
## Summary
- allow clients to register PostgreSQL connections via `/api/connection`
- store connections in-memory and let requests specify connection id and schema
- expose GET `/api/connection` to list ids of all registered connections

## Testing
- `./gradlew compileJava`
- `./gradlew test` *(fails: Could not GET from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68bff7786f188320a313eea1e50b24bc