### PR TITLE
Fix connection endpoint and add optional DB info field

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,18 @@ curl -s -X POST http://localhost:8080/api/analyze \  -H 'Content-Type: applicati
 ## Пример полного флоу через API
 
 ```bash
-# 1) создаём подключение к PostgreSQL
-curl -s -X POST http://localhost:8080/api/connections \
+# 1) создаём подключение к PostgreSQL (jdbcUrl соберётся автоматически)
+curl -s -X POST http://localhost:8080/connections \
   -H 'Content-Type: application/json' \
   -d '{
         "host":"db", "port":5432,
-        "database":"app", "user":"u", "password":"p"
+        "database":"app", "user":"u", "password":"p",
+        "info":"описание (опц.)"
       }'
 # -> {"id":"conn-1"}
 
 # 2) смотрим список активных подключений
-curl -s http://localhost:8080/api/connections | jq
+curl -s http://localhost:8080/connections | jq
 
 # 3) отправляем запрос на анализ в конкретную БД/схему
 curl -s -X POST http://localhost:8080/api/analyze \

--- a/src/main/java/dev/paraplan/app/controller/ConnectionController.java
+++ b/src/main/java/dev/paraplan/app/controller/ConnectionController.java
@@ -19,7 +19,8 @@ public class ConnectionController {
 
     @PostMapping
     public Map<String, String> create(@RequestBody ConnectionRequest req) {
-        String id = registry.create(req.url(), req.username(), req.password());
+        String jdbcUrl = String.format("jdbc:postgresql://%s:%d/%s", req.host(), req.port(), req.database());
+        String id = registry.create(jdbcUrl, req.username(), req.password(), req.info());
         return Map.of("id", id);
     }
 

--- a/src/main/java/dev/paraplan/app/model/ConnectionInfo.java
+++ b/src/main/java/dev/paraplan/app/model/ConnectionInfo.java
@@ -1,3 +1,3 @@
 package dev.paraplan.app.model;
 
-public record ConnectionInfo(String id, String url, String username) {}
+public record ConnectionInfo(String id, String url, String username, String info) {}

--- a/src/main/java/dev/paraplan/app/model/ConnectionRequest.java
+++ b/src/main/java/dev/paraplan/app/model/ConnectionRequest.java
@@ -1,3 +1,12 @@
 package dev.paraplan.app.model;
 
-public record ConnectionRequest(String url, String username, String password) {}
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ConnectionRequest(
+        String host,
+        int port,
+        String database,
+        @JsonProperty("user") String username,
+        String password,
+        String info
+) {}

--- a/src/main/java/dev/paraplan/app/service/ConnectionRegistry.java
+++ b/src/main/java/dev/paraplan/app/service/ConnectionRegistry.java
@@ -20,7 +20,7 @@ public class ConnectionRegistry {
     private final Map<String, HikariDataSource> sources = new ConcurrentHashMap<>();
     private final Map<String, ConnectionInfo> infos = new ConcurrentHashMap<>();
 
-    public String create(String url, String username, String password) {
+    public String create(String url, String username, String password, String info) {
         HikariConfig cfg = new HikariConfig();
         cfg.setJdbcUrl(url);
         cfg.setUsername(username);
@@ -30,7 +30,7 @@ public class ConnectionRegistry {
         HikariDataSource ds = new HikariDataSource(cfg);
         String id = UUID.randomUUID().toString();
         sources.put(id, ds);
-        infos.put(id, new ConnectionInfo(id, url, username));
+        infos.put(id, new ConnectionInfo(id, url, username, info));
         return id;
     }
 

--- a/src/test/java/dev/paraplan/app/ExtendedSqlCoverageIT.java
+++ b/src/test/java/dev/paraplan/app/ExtendedSqlCoverageIT.java
@@ -44,9 +44,11 @@ class ExtendedSqlCoverageIT {
     private String createConnection() {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        Map<String, String> payload = Map.of(
-                "url", PG.getJdbcUrl(),
-                "username", PG.getUsername(),
+        Map<String, Object> payload = Map.of(
+                "host", PG.getHost(),
+                "port", PG.getMappedPort(5432),
+                "database", PG.getDatabaseName(),
+                "user", PG.getUsername(),
                 "password", PG.getPassword()
         );
         ResponseEntity<Map> resp = rest.postForEntity("http://localhost:" + port + "/connections",

--- a/src/test/java/dev/paraplan/app/ParaPlanIntegrationIT.java
+++ b/src/test/java/dev/paraplan/app/ParaPlanIntegrationIT.java
@@ -47,9 +47,11 @@ class ParaPlanIntegrationIT {
     private String createConnection() {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        Map<String, String> payload = Map.of(
-                "url", PG.getJdbcUrl(),
-                "username", PG.getUsername(),
+        Map<String, Object> payload = Map.of(
+                "host", PG.getHost(),
+                "port", PG.getMappedPort(5432),
+                "database", PG.getDatabaseName(),
+                "user", PG.getUsername(),
                 "password", PG.getPassword()
         );
         ResponseEntity<Map> resp = rest.postForEntity("http://localhost:" + port + "/connections",


### PR DESCRIPTION
## Summary
- correct README and API usage to `/connections`
- build JDBC URL from host/port/db and allow optional `info`
- update integration tests for new connection request format

## Testing
- `./gradlew test` *(fails: Could not resolve org.springframework:spring-context:6.1.8, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c013dc44f0832095962bc9b1170fbc