### PR TITLE
Enable CORS for frontend development

### DIFF
--- a/src/main/java/dev/paraplan/app/config/CorsConfig.java
+++ b/src/main/java/dev/paraplan/app/config/CorsConfig.java
@@ -1,0 +1,22 @@
+package dev.paraplan.app.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+  @Bean
+  public WebMvcConfigurer corsConfigurer() {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins("http://localhost:5173")
+            .allowedMethods("*");
+      }
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- allow requests from localhost frontend by configuring CORS

## Testing
- `./gradlew test` *(fails: Could not resolve org.springframework:spring-context:6.1.8 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68c0618ca98c8320a229378139adedcf